### PR TITLE
chore(deps): bump aiohttp to 3.14.3 (fixes 3 Dependabot alerts)

### DIFF
--- a/worker_plan/pyproject.toml
+++ b/worker_plan/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.13"
 dependencies = [
     "aiofiles==25.1.0",
     "aiohappyeyeballs==2.6.2",
-    "aiohttp==3.14.1",
+    "aiohttp==3.14.3",
     "aiosignal==1.4.0",
     "annotated-types==0.7.0",
     "anyio==4.14.0",


### PR DESCRIPTION
Bumps `aiohttp` in `worker_plan/pyproject.toml` from 3.14.1 to 3.14.3.

Closes the three open Dependabot alerts on the repo:

| Alert | Severity | Advisory |
|---|---|---|
| #195 | high | GHSA-cq5v-8q36-5273 — out-of-bounds heap read in the C HTTP response parser error path (malformed chunked response) |
| #194 | medium | GHSA-mfx4-hv73-q22v — HTTP request smuggling via WebSocket upgrade |
| #193 | medium | GHSA-mq44-7p77-q5h7 — WebSocket client accepts compressed frames without negotiated permessage-deflate |

3.14.3 is the first stable release patched against all three (currently the latest aiohttp release).