### PR TITLE
fix(billing): reject Stripe webhooks with no signature header

### DIFF
--- a/frontend_multi_user/src/billing.py
+++ b/frontend_multi_user/src/billing.py
@@ -289,6 +289,8 @@ def stripe_webhook():
     event: Any = None
     try:
         if webhook_secret:
+            if sig_header is None:
+                raise ValueError("Missing Stripe-Signature header")
             event = stripe.Webhook.construct_event(payload, sig_header, webhook_secret)
         else:
             event = json.loads(payload)


### PR DESCRIPTION
Unblocks the typecheck failure on #860 (bump stripe 15.3.1 -> 15.5.1).

stripe 15.5.1 tightened `Webhook.construct_event`'s `sig_header` parameter to `str`, so passing the possibly-absent `Stripe-Signature` header straight through fails pyright:

```
frontend_multi_user/src/billing.py:292:61 - error: Argument of type \"str | None\" cannot be assigned to parameter \"sig_header\" of type \"str\"
```

This raises explicitly when the header is missing. The raise lands in the existing `except` block, so behaviour is unchanged: logged, recorded with `has_signature_header=False`, answered with 400 - the same outcome `construct_event` produced for a missing signature.

Verified against stripe 15.5.1 with pyright: the old call pattern reproduces the CI error, the guarded one is clean.

After this merges, #860 needs a dependabot rebase to pick it up.