### PR TITLE
deps: bump tornado to 6.5.8 in worker_plan (GHSA-mpf4-983q-p7j4)

### DIFF
--- a/worker_plan/pyproject.toml
+++ b/worker_plan/pyproject.toml
@@ -102,7 +102,7 @@ dependencies = [
     "striprtf==0.0.26",
     "tenacity==9.1.4",
     "tiktoken==0.13.0",
-    "tornado==6.5.7",
+    "tornado==6.5.8",
     "tqdm==4.67.1",
     "typer==0.24.1",
     "typing-inspect==0.9.0",


### PR DESCRIPTION
Updates tornado to address GHSA-mpf4-983q-p7j4.

Evidence:
- worker_plan/pyproject.toml pinned tornado==6.5.7
- osv-scanner reported GHSA-mpf4-983q-p7j4 (plus GHSA-8423-8fgw-73vq, GHSA-wwv5-g3v4-889x) on tornado 6.5.7 before the update
- updated version: 6.5.8

Validation:
- osv-scanner reports no issues after the update (all three tornado advisories cleared)
- worker_plan tests pass: 256 tests OK (13 skipped) in worker_plan_internal, 22 tests OK in worker_plan_api, with tornado 6.5.8 installed
- full `python test.py` suite has 23 pre-existing errors from mcp_cloud tests needing a postgres host (database_postgres) and cross-service deps; the same errors occur on main without this change

Scope: dependency pin in worker_plan/pyproject.toml only.
