### PR TITLE
Replace retired Gemini 2.5 Flash Lite default and pin deepseek-v4-flash to Baidu fp8

### DIFF
--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -220,7 +220,7 @@
         "pricing_kind": "paid"
     },
     "openrouter-deepseek-deepseek-v4-flash-0731": {
-        "comment": "2026 Jul 31. $0.04998 input. $0.09996 output. Per M tokens.",
+        "comment": "2026 Jul 31. $0.04998 input. $0.09996 output. Per M tokens. Pinned to the Baidu fp8 endpoint (no fallbacks) so OpenRouter does not route between the ~30 providers hosting this model.",
         "priority": 1,
         "luigi_workers": 4,
         "class": "OpenRouter",
@@ -233,7 +233,12 @@
             "is_function_calling_model": false,
             "is_chat_model": true,
             "max_tokens": 32000,
-            "max_retries": 5
+            "max_retries": 5,
+            "additional_kwargs": {
+                "extra_body": {
+                    "provider": {"order": ["baidu/fp8"], "allow_fallbacks": false}
+                }
+            }
         },
         "model_info_url": "https://openrouter.ai/deepseek/deepseek-v4-flash-0731",
         "pricing": {

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -196,9 +196,54 @@
         },
         "pricing_kind": "free"
     },
-    "openrouter-gemini-2.5-flash-lite-preview-09-2025": {
-        "comment": "Created Sep 25, 2025. 1,048,576 context. $0.10/M input tokens. $0.40/M output tokens.",
+    "openrouter-z-ai-glm-5.3-flash": {
+        "comment": "2026 Aug 26. $0.075 input. $0.25 output. Per M tokens.",
+        "priority": 2,
+        "luigi_workers": 4,
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "z-ai/glm-5.3-flash",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 1,
+            "timeout": 60.0,
+            "context_window": 1048576,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 32000,
+            "max_retries": 5
+        },
+        "model_info_url": "https://openrouter.ai/z-ai/glm-5.3-flash",
+        "pricing": {
+            "input_per_million_tokens": 0.075,
+            "output_per_million_tokens": 0.25
+        },
+        "pricing_kind": "paid"
+    },
+    "openrouter-deepseek-deepseek-v4-flash-0731": {
+        "comment": "2026 Jul 31. $0.04998 input. $0.09996 output. Per M tokens.",
         "priority": 1,
+        "luigi_workers": 4,
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "deepseek/deepseek-v4-flash-0731",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 1,
+            "timeout": 60.0,
+            "context_window": 1048576,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 32000,
+            "max_retries": 5
+        },
+        "model_info_url": "https://openrouter.ai/deepseek/deepseek-v4-flash-0731",
+        "pricing": {
+            "input_per_million_tokens": 0.05,
+            "output_per_million_tokens": 0.1
+        },
+        "pricing_kind": "paid"
+    },
+    "openrouter-gemini-2.5-flash-lite-preview-09-2025": {
+        "comment": "No longer available. Created Sep 25, 2025. 1,048,576 context. $0.10/M input tokens. $0.40/M output tokens.",
         "luigi_workers": 4,
         "class": "OpenRouter",
         "arguments": {
@@ -220,7 +265,7 @@
         "pricing_kind": "paid"
     },
     "openrouter-gemini-2.0-flash-001": {
-        "comment": "Created Feb 25, 2025. 1,048,576 context. $0.10/M input tokens. $0.40/M output tokens. Alas price have increased and throughput dropped to roughly half its original speed. It was my favorite model, cheap and fast.",
+        "comment": "No longer available. Created Feb 25, 2025. 1,048,576 context. $0.10/M input tokens. $0.40/M output tokens. Alas price have increased and throughput dropped to roughly half its original speed. It was my favorite model, cheap and fast.",
         "luigi_workers": 4,
         "model_info_url": "https://openrouter.ai/google/gemini-2.0-flash-001",
         "class": "OpenRouter",
@@ -265,7 +310,7 @@
     },
     "openrouter-openai-gpt-4o-mini": {
         "comment": "This is medium fast. Created Jul 18, 2024. 128,000 context. Starting at $0.15/M input tokens. Starting at $0.60/M output tokens.",
-        "priority": 2,
+        "priority": 4,
         "luigi_workers": 4,
         "class": "OpenRouter",
         "arguments": {

--- a/worker_plan/tests/test_llm_factory.py
+++ b/worker_plan/tests/test_llm_factory.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import patch
+
+from worker_plan_internal.llm_factory import get_llm
+from worker_plan_internal.utils.planexe_llmconfig import PlanExeLLMConfig
+
+
+def make_config(llm_config_dict: dict) -> PlanExeLLMConfig:
+    return PlanExeLLMConfig(
+        llm_config_json_path=None,
+        llm_config_dict_raw=llm_config_dict,
+        llm_config_dict=llm_config_dict,
+    )
+
+
+class TestGetLLMOpenRouterAdditionalKwargs(unittest.TestCase):
+    def test_extra_body_from_config_survives_app_info_headers(self):
+        provider_pin = {"order": ["baidu/fp8"], "allow_fallbacks": False}
+        config = make_config({
+            "pinned": {
+                "class": "OpenRouter",
+                "arguments": {
+                    "model": "deepseek/deepseek-v4-flash-0731",
+                    "api_key": "sk-test",
+                    "additional_kwargs": {
+                        "extra_body": {"provider": provider_pin}
+                    },
+                },
+            }
+        })
+
+        with patch("worker_plan_internal.llm_factory._load_llm_config", return_value=config):
+            llm = get_llm("pinned")
+
+        self.assertEqual(llm.additional_kwargs["extra_body"], {"provider": provider_pin})
+        self.assertIn("HTTP-Referer", llm.additional_kwargs["extra_headers"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/worker_plan/worker_plan_internal/llm_factory.py
+++ b/worker_plan/worker_plan_internal/llm_factory.py
@@ -265,15 +265,14 @@ def get_llm(llm_name: Optional[str] = None, model_profile: Optional[ModelProfile
     if class_name == "OpenRouter" and SEND_APP_INFO_TO_OPENROUTER:
         # https://openrouter.ai/rankings
         # https://openrouter.ai/docs/api-reference/overview#headers
-        arguments_extra = {
-            "additional_kwargs": {
-                "extra_headers": {
-                    "HTTP-Referer": "https://github.com/PlanExeOrg/PlanExe",
-                    "X-Title": "PlanExe - the premier planning tool for AI agents"
-                }
-            }
+        # Merge into any additional_kwargs from the config (e.g. extra_body
+        # with OpenRouter provider routing) rather than replacing them.
+        additional_kwargs = dict(arguments.get("additional_kwargs", {}))
+        additional_kwargs["extra_headers"] = {
+            "HTTP-Referer": "https://github.com/PlanExeOrg/PlanExe",
+            "X-Title": "PlanExe - the premier planning tool for AI agents"
         }
-        arguments.update(arguments_extra)
+        arguments["additional_kwargs"] = additional_kwargs
 
     # Ensure a request timeout is set so LLM calls don't hang indefinitely.
     # Ollama uses "request_timeout"; all others (OpenRouter, Anthropic, LMStudio)


### PR DESCRIPTION
## Summary

- Gemini 2.5 Flash Lite has been retired, so baseline.json adds alternative OpenRouter models and promotes deepseek-v4-flash-0731 as the new priority-1 default.
- The deepseek-v4-flash entry is pinned to the OpenRouter endpoint tag `baidu/fp8` with fallbacks disabled, so OpenRouter stops load-balancing across the ~30 providers hosting that model.
- Fixes a bug in `llm_factory.py`: the OpenRouter app-info header injection replaced the whole `additional_kwargs` dict, silently dropping any `extra_body` set in the JSON config. It now merges.
- Adds a regression test in `worker_plan/tests/test_llm_factory.py` covering the merge.

## Verification

- New test failed with KeyError before the fix, passes after.
- Live completion through the real factory and config reports provider Baidu.
- Root `test.py`: 399 tests, only the 23 pre-existing mcp_cloud errors that need PostgreSQL.
- `ruff check --select=E9,F63,F7,F82 .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)