### PR TITLE
Make mercury-2.5-preview the default model, replacing retired gemini-2.5-flash-lite

### DIFF
--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -135,9 +135,8 @@
         },
         "pricing_kind": "paid"
     },
-    "openrouter-nemotron-3.5-lightning-free": {
+    "xopenrouter-nemotron-3.5-lightning-free": {
         "comment": "Released Aug 11, 2026. NVIDIA MoE, 3B active of 30B params, built for high-throughput agentic work. Single provider (Nvidia, nvfp4). 1,000,000 context, 65,536 max output. $0/M input tokens. $0/M output tokens.",
-        "priority": 1,
         "luigi_workers": 4,
         "model_info_url": "https://openrouter.ai/nvidia/nemotron-3.5-lightning",
         "class": "OpenRouter",
@@ -210,6 +209,7 @@
     },
     "openrouter-laguna-s-2.1-free": {
         "comment": "Released Jul 21, 2026. Poolside coding-agent model, 8B active of 118B params. Single provider (Poolside, fp4). 262,144 context, 32,768 max output. $0/M input tokens. $0/M output tokens.",
+        "priority": 1,
         "luigi_workers": 4,
         "model_info_url": "https://openrouter.ai/poolside/laguna-s-2.1",
         "class": "OpenRouter",

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -135,6 +135,99 @@
         },
         "pricing_kind": "paid"
     },
+    "openrouter-nemotron-3.5-lightning-free": {
+        "comment": "Released Aug 11, 2026. NVIDIA MoE, 3B active of 30B params, built for high-throughput agentic work. Single provider (Nvidia, nvfp4). 1,000,000 context, 65,536 max output. $0/M input tokens. $0/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/nvidia/nemotron-3.5-lightning",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "nvidia/nemotron-3.5-lightning:free",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 1000000,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 32000,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0,
+            "output_per_million_tokens": 0
+        },
+        "pricing_kind": "free"
+    },
+    "openrouter-nemotron-3.5-lightning": {
+        "comment": "Released Aug 11, 2026. NVIDIA MoE, 3B active of 30B params, built for high-throughput agentic work. Pinned to DeepInfra bf16 (no fallbacks); CoreWeave is the only alternative at a slightly higher price. 262,144 context, 131,072 max output. $0.08/M input tokens. $0.20/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/nvidia/nemotron-3.5-lightning",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "nvidia/nemotron-3.5-lightning",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 262144,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 32000,
+            "max_retries": 5,
+            "additional_kwargs": {
+                "extra_body": {
+                    "provider": {"order": ["deepinfra/bf16"], "allow_fallbacks": false}
+                }
+            }
+        },
+        "pricing": {
+            "input_per_million_tokens": 0.08,
+            "output_per_million_tokens": 0.2
+        },
+        "pricing_kind": "paid"
+    },
+    "openrouter-solar-pro4": {
+        "comment": "Released Aug 10, 2026. Upstage's cost-efficient model for long-horizon and document-heavy tasks. Hosted only by Upstage (two endpoints, one zero-data-retention, same price). 524,288 context, 131,072 max output. $0.03/M input tokens. $0.12/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/upstage/solar-pro4",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "upstage/solar-pro4",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 524288,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 32000,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0.03,
+            "output_per_million_tokens": 0.12
+        },
+        "pricing_kind": "paid"
+    },
+    "openrouter-laguna-s-2.1-free": {
+        "comment": "Released Jul 21, 2026. Poolside coding-agent model, 8B active of 118B params. Single provider (Poolside, fp4). 262,144 context, 32,768 max output. $0/M input tokens. $0/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/poolside/laguna-s-2.1",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "poolside/laguna-s-2.1:free",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 262144,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 32000,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0,
+            "output_per_million_tokens": 0
+        },
+        "pricing_kind": "free"
+    },
     "openrouter-dots-3-note-preview-free": {
         "comment": "Released Aug 14, 2026. Open-weight MoE from Dots Studio, 16B active of 280B params, lightest of the Dots 3 family. Single provider (AtlasCloud, fp8). 512,000 context, 460,800 max output. $0/M input tokens. $0/M output tokens.",
         "luigi_workers": 4,

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -135,6 +135,28 @@
         },
         "pricing_kind": "paid"
     },
+    "openrouter-dots-3-note-preview-free": {
+        "comment": "Released Aug 14, 2026. Open-weight MoE from Dots Studio, 16B active of 280B params, lightest of the Dots 3 family. Single provider (AtlasCloud, fp8). 512,000 context, 460,800 max output. $0/M input tokens. $0/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/dots-studio/dots-3-note-preview",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "dots-studio/dots-3-note-preview:free",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 512000,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 32000,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0,
+            "output_per_million_tokens": 0
+        },
+        "pricing_kind": "free"
+    },
     "openrouter-ling-3.0-flash-fin-free": {
         "comment": "Released Aug 27, 2026. Finance-focused MoE from inclusionAI built on Ling 3.0 Flash, 5.1B active of 124B params. Single provider (Novita). 262,144 context, 32,768 max output. $0/M input tokens. $0/M output tokens.",
         "luigi_workers": 4,

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -207,9 +207,8 @@
         },
         "pricing_kind": "paid"
     },
-    "openrouter-laguna-s-2.1-free": {
+    "yopenrouter-laguna-s-2.1-free": {
         "comment": "Released Jul 21, 2026. Poolside coding-agent model, 8B active of 118B params. Single provider (Poolside, fp4). 262,144 context, 32,768 max output. $0/M input tokens. $0/M output tokens.",
-        "priority": 1,
         "luigi_workers": 4,
         "model_info_url": "https://openrouter.ai/poolside/laguna-s-2.1",
         "class": "OpenRouter",
@@ -230,7 +229,7 @@
         },
         "pricing_kind": "free"
     },
-    "openrouter-dots-3-note-preview-free": {
+    "xopenrouter-dots-3-note-preview-free": {
         "comment": "Released Aug 14, 2026. Open-weight MoE from Dots Studio, 16B active of 280B params, lightest of the Dots 3 family. Single provider (AtlasCloud, fp8). 512,000 context, 460,800 max output. $0/M input tokens. $0/M output tokens.",
         "luigi_workers": 4,
         "model_info_url": "https://openrouter.ai/dots-studio/dots-3-note-preview",
@@ -254,6 +253,7 @@
     },
     "openrouter-ling-3.0-flash-fin-free": {
         "comment": "Released Aug 27, 2026. Finance-focused MoE from inclusionAI built on Ling 3.0 Flash, 5.1B active of 124B params. Single provider (Novita). 262,144 context, 32,768 max output. $0/M input tokens. $0/M output tokens.",
+        "priority": 1,
         "luigi_workers": 4,
         "model_info_url": "https://openrouter.ai/inclusionai/ling-3.0-flash-fin",
         "class": "OpenRouter",

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -135,6 +135,28 @@
         },
         "pricing_kind": "paid"
     },
+    "openrouter-ling-3.0-flash-fin-free": {
+        "comment": "Released Aug 27, 2026. Finance-focused MoE from inclusionAI built on Ling 3.0 Flash, 5.1B active of 124B params. Single provider (Novita). 262,144 context, 32,768 max output. $0/M input tokens. $0/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/inclusionai/ling-3.0-flash-fin",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "inclusionai/ling-3.0-flash-fin:free",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 262144,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 32000,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0,
+            "output_per_million_tokens": 0
+        },
+        "pricing_kind": "free"
+    },
     "openrouter-ling-3.0-flash-sante-free": {
         "comment": "Released Sep 4, 2026. Health/medicine-focused MoE from inclusionAI built on Ling 3.0 Flash, 5.1B active of 124B params. Single provider (Novita). 262,144 context, 32,768 max output. $0/M input tokens. $0/M output tokens.",
         "luigi_workers": 4,

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -108,6 +108,33 @@
         },
         "pricing_kind": "paid"
     },
+    "openrouter-ling-3.0-flash": {
+        "comment": "Released Jul 23, 2026. General-purpose MoE from inclusionAI, 5.1B active of 124B params, built for token efficiency. Pinned to Novita (no fallbacks): the only other provider, DeepInfra, is 3x the price with a 131k context. 262,144 context, 32,768 max output. $0.021/M input tokens. $0.063/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/inclusionai/ling-3.0-flash",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "inclusionai/ling-3.0-flash",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 262144,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 32000,
+            "max_retries": 5,
+            "additional_kwargs": {
+                "extra_body": {
+                    "provider": {"order": ["novita"], "allow_fallbacks": false}
+                }
+            }
+        },
+        "pricing": {
+            "input_per_million_tokens": 0.021,
+            "output_per_million_tokens": 0.063
+        },
+        "pricing_kind": "paid"
+    },
     "openrouter-ling-3.0-flash-sante-free": {
         "comment": "Released Sep 4, 2026. Health/medicine-focused MoE from inclusionAI built on Ling 3.0 Flash, 5.1B active of 124B params. Single provider (Novita). 262,144 context, 32,768 max output. $0/M input tokens. $0/M output tokens.",
         "luigi_workers": 4,

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -184,6 +184,29 @@
         },
         "pricing_kind": "paid"
     },
+    "openrouter-mercury-2.5-preview": {
+        "comment": "Released Aug 31, 2026. Inception's diffusion LLM: generates and refines many tokens in parallel instead of sequentially, marketed as the fastest reasoning model. Single provider (Inception). 260,000 context, 65,536 max output. $0.04/M input tokens. $0.15/M output tokens.",
+        "priority": 1,
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/inception/mercury-2.5-preview",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "inception/mercury-2.5-preview",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 260000,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 32000,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0.04,
+            "output_per_million_tokens": 0.15
+        },
+        "pricing_kind": "paid"
+    },
     "openrouter-solar-pro4": {
         "comment": "Released Aug 10, 2026. Upstage's cost-efficient model for long-horizon and document-heavy tasks. Hosted only by Upstage (two endpoints, one zero-data-retention, same price). 524,288 context, 131,072 max output. $0.03/M input tokens. $0.12/M output tokens.",
         "priority": 2,
@@ -251,9 +274,8 @@
         },
         "pricing_kind": "free"
     },
-    "openrouter-ling-3.0-flash-fin-free": {
+    "xopenrouter-ling-3.0-flash-fin-free": {
         "comment": "Released Aug 27, 2026. Finance-focused MoE from inclusionAI built on Ling 3.0 Flash, 5.1B active of 124B params. Single provider (Novita). 262,144 context, 32,768 max output. $0/M input tokens. $0/M output tokens.",
-        "priority": 1,
         "luigi_workers": 4,
         "model_info_url": "https://openrouter.ai/inclusionai/ling-3.0-flash-fin",
         "class": "OpenRouter",

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -137,6 +137,7 @@
     },
     "openrouter-nemotron-3.5-lightning-free": {
         "comment": "Released Aug 11, 2026. NVIDIA MoE, 3B active of 30B params, built for high-throughput agentic work. Single provider (Nvidia, nvfp4). 1,000,000 context, 65,536 max output. $0/M input tokens. $0/M output tokens.",
+        "priority": 1,
         "luigi_workers": 4,
         "model_info_url": "https://openrouter.ai/nvidia/nemotron-3.5-lightning",
         "class": "OpenRouter",
@@ -186,6 +187,7 @@
     },
     "openrouter-solar-pro4": {
         "comment": "Released Aug 10, 2026. Upstage's cost-efficient model for long-horizon and document-heavy tasks. Hosted only by Upstage (two endpoints, one zero-data-retention, same price). 524,288 context, 131,072 max output. $0.03/M input tokens. $0.12/M output tokens.",
+        "priority": 2,
         "luigi_workers": 4,
         "model_info_url": "https://openrouter.ai/upstage/solar-pro4",
         "class": "OpenRouter",
@@ -384,7 +386,6 @@
     },
     "openrouter-z-ai-glm-5.3-flash": {
         "comment": "2026 Aug 26. $0.075 input. $0.25 output. Per M tokens.",
-        "priority": 2,
         "luigi_workers": 4,
         "class": "OpenRouter",
         "arguments": {
@@ -407,7 +408,6 @@
     },
     "openrouter-deepseek-deepseek-v4-flash-0731": {
         "comment": "2026 Jul 31. $0.04998 input. $0.09996 output. Per M tokens. Pinned to the Baidu fp8 endpoint (no fallbacks) so OpenRouter does not route between the ~30 providers hosting this model.",
-        "priority": 1,
         "luigi_workers": 4,
         "class": "OpenRouter",
         "arguments": {

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -135,28 +135,6 @@
         },
         "pricing_kind": "paid"
     },
-    "xopenrouter-nemotron-3.5-lightning-free": {
-        "comment": "Released Aug 11, 2026. NVIDIA MoE, 3B active of 30B params, built for high-throughput agentic work. Single provider (Nvidia, nvfp4). 1,000,000 context, 65,536 max output. $0/M input tokens. $0/M output tokens.",
-        "luigi_workers": 4,
-        "model_info_url": "https://openrouter.ai/nvidia/nemotron-3.5-lightning",
-        "class": "OpenRouter",
-        "arguments": {
-            "model": "nvidia/nemotron-3.5-lightning:free",
-            "api_key": "${OPENROUTER_API_KEY}",
-            "temperature": 0.1,
-            "timeout": 60.0,
-            "context_window": 1000000,
-            "is_function_calling_model": false,
-            "is_chat_model": true,
-            "max_tokens": 32000,
-            "max_retries": 5
-        },
-        "pricing": {
-            "input_per_million_tokens": 0,
-            "output_per_million_tokens": 0
-        },
-        "pricing_kind": "free"
-    },
     "openrouter-nemotron-3.5-lightning": {
         "comment": "Released Aug 11, 2026. NVIDIA MoE, 3B active of 30B params, built for high-throughput agentic work. Pinned to DeepInfra bf16 (no fallbacks); CoreWeave is the only alternative at a slightly higher price. 262,144 context, 131,072 max output. $0.08/M input tokens. $0.20/M output tokens.",
         "luigi_workers": 4,
@@ -229,94 +207,6 @@
             "output_per_million_tokens": 0.12
         },
         "pricing_kind": "paid"
-    },
-    "yopenrouter-laguna-s-2.1-free": {
-        "comment": "Released Jul 21, 2026. Poolside coding-agent model, 8B active of 118B params. Single provider (Poolside, fp4). 262,144 context, 32,768 max output. $0/M input tokens. $0/M output tokens.",
-        "luigi_workers": 4,
-        "model_info_url": "https://openrouter.ai/poolside/laguna-s-2.1",
-        "class": "OpenRouter",
-        "arguments": {
-            "model": "poolside/laguna-s-2.1:free",
-            "api_key": "${OPENROUTER_API_KEY}",
-            "temperature": 0.1,
-            "timeout": 60.0,
-            "context_window": 262144,
-            "is_function_calling_model": false,
-            "is_chat_model": true,
-            "max_tokens": 32000,
-            "max_retries": 5
-        },
-        "pricing": {
-            "input_per_million_tokens": 0,
-            "output_per_million_tokens": 0
-        },
-        "pricing_kind": "free"
-    },
-    "xopenrouter-dots-3-note-preview-free": {
-        "comment": "Released Aug 14, 2026. Open-weight MoE from Dots Studio, 16B active of 280B params, lightest of the Dots 3 family. Single provider (AtlasCloud, fp8). 512,000 context, 460,800 max output. $0/M input tokens. $0/M output tokens.",
-        "luigi_workers": 4,
-        "model_info_url": "https://openrouter.ai/dots-studio/dots-3-note-preview",
-        "class": "OpenRouter",
-        "arguments": {
-            "model": "dots-studio/dots-3-note-preview:free",
-            "api_key": "${OPENROUTER_API_KEY}",
-            "temperature": 0.1,
-            "timeout": 60.0,
-            "context_window": 512000,
-            "is_function_calling_model": false,
-            "is_chat_model": true,
-            "max_tokens": 32000,
-            "max_retries": 5
-        },
-        "pricing": {
-            "input_per_million_tokens": 0,
-            "output_per_million_tokens": 0
-        },
-        "pricing_kind": "free"
-    },
-    "xopenrouter-ling-3.0-flash-fin-free": {
-        "comment": "Released Aug 27, 2026. Finance-focused MoE from inclusionAI built on Ling 3.0 Flash, 5.1B active of 124B params. Single provider (Novita). 262,144 context, 32,768 max output. $0/M input tokens. $0/M output tokens.",
-        "luigi_workers": 4,
-        "model_info_url": "https://openrouter.ai/inclusionai/ling-3.0-flash-fin",
-        "class": "OpenRouter",
-        "arguments": {
-            "model": "inclusionai/ling-3.0-flash-fin:free",
-            "api_key": "${OPENROUTER_API_KEY}",
-            "temperature": 0.1,
-            "timeout": 60.0,
-            "context_window": 262144,
-            "is_function_calling_model": false,
-            "is_chat_model": true,
-            "max_tokens": 32000,
-            "max_retries": 5
-        },
-        "pricing": {
-            "input_per_million_tokens": 0,
-            "output_per_million_tokens": 0
-        },
-        "pricing_kind": "free"
-    },
-    "openrouter-ling-3.0-flash-sante-free": {
-        "comment": "Released Sep 4, 2026. Health/medicine-focused MoE from inclusionAI built on Ling 3.0 Flash, 5.1B active of 124B params. Single provider (Novita). 262,144 context, 32,768 max output. $0/M input tokens. $0/M output tokens.",
-        "luigi_workers": 4,
-        "model_info_url": "https://openrouter.ai/inclusionai/ling-3.0-flash-sante",
-        "class": "OpenRouter",
-        "arguments": {
-            "model": "inclusionai/ling-3.0-flash-sante:free",
-            "api_key": "${OPENROUTER_API_KEY}",
-            "temperature": 0.1,
-            "timeout": 60.0,
-            "context_window": 262144,
-            "is_function_calling_model": false,
-            "is_chat_model": true,
-            "max_tokens": 32000,
-            "max_retries": 5
-        },
-        "pricing": {
-            "input_per_million_tokens": 0,
-            "output_per_million_tokens": 0
-        },
-        "pricing_kind": "free"
     },
     "openrouter-ling-2.6-1t-free": {
         "comment": "Released Apr 23, 2026. Scheduled to be removed from OpenRouter on Apr 30, 2026. 262,144 context. $0/M input tokens. $0/M output tokens.",

--- a/llm_config/baseline.json
+++ b/llm_config/baseline.json
@@ -108,6 +108,28 @@
         },
         "pricing_kind": "paid"
     },
+    "openrouter-ling-3.0-flash-sante-free": {
+        "comment": "Released Sep 4, 2026. Health/medicine-focused MoE from inclusionAI built on Ling 3.0 Flash, 5.1B active of 124B params. Single provider (Novita). 262,144 context, 32,768 max output. $0/M input tokens. $0/M output tokens.",
+        "luigi_workers": 4,
+        "model_info_url": "https://openrouter.ai/inclusionai/ling-3.0-flash-sante",
+        "class": "OpenRouter",
+        "arguments": {
+            "model": "inclusionai/ling-3.0-flash-sante:free",
+            "api_key": "${OPENROUTER_API_KEY}",
+            "temperature": 0.1,
+            "timeout": 60.0,
+            "context_window": 262144,
+            "is_function_calling_model": false,
+            "is_chat_model": true,
+            "max_tokens": 32000,
+            "max_retries": 5
+        },
+        "pricing": {
+            "input_per_million_tokens": 0,
+            "output_per_million_tokens": 0
+        },
+        "pricing_kind": "free"
+    },
     "openrouter-ling-2.6-1t-free": {
         "comment": "Released Apr 23, 2026. Scheduled to be removed from OpenRouter on Apr 30, 2026. 262,144 context. $0/M input tokens. $0/M output tokens.",
         "luigi_workers": 4,


### PR DESCRIPTION
## Summary

Gemini 2.5 Flash Lite was retired. Full plan generation on the interim default (deepseek-v4-flash) took 3 to 4 hours versus about 15 minutes before. This branch trials a set of faster OpenRouter models and settles on Inception's Mercury 2.5 Preview, a diffusion LLM that generates tokens in parallel.

- `openrouter-mercury-2.5-preview` is now priority 1. `openrouter-solar-pro4` is priority 2. Priorities 3 and 4 are unchanged.
- New entries kept from the experiment: `openrouter-ling-3.0-flash` (pinned to Novita), `openrouter-nemotron-3.5-lightning` (pinned to DeepInfra bf16), `openrouter-solar-pro4`, `openrouter-mercury-2.5-preview`.
- Candidates that turned out too slow were removed again before this PR.
- `thinkingmachines/inkling-small:free` was evaluated but not added: OpenRouter returns 403, it is restricted to allowlisted agentic harnesses.

## Verification

- Every new entry was smoke-tested through `get_llm()` with the real config; Mercury answered in about 1.4s with heavy hidden reasoning and no latency penalty.
- `baseline.json` parses; no keys removed relative to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)